### PR TITLE
(fix) remove exchange intermediary class

### DIFF
--- a/merkato/exchanges/exchange.py
+++ b/merkato/exchanges/exchange.py
@@ -1,6 +1,6 @@
 import time
 
-from merkato.exchanges.tux_exchange import TuxExchange
+from merkato.exchanges.tux_exchange.exchange import TuxExchange
 
 DEBUG = True
 

--- a/merkato/exchanges/tux_exchange/tux_exchange.py
+++ b/merkato/exchanges/tux_exchange/tux_exchange.py
@@ -5,9 +5,9 @@ import math
 import requests
 import time
 import urllib.parse
-
+from merkato.exchanges.tux_exchange.utils import getQueryParameters
 from merkato.exchanges.exchange_base import ExchangeBase
-
+from merkato.constants import BUY, SELL
 DEBUG = True
 
 
@@ -24,13 +24,7 @@ class TuxExchange(ExchangeBase):
             :param ask: float
             :param ticker: string
         '''
-        query_parameters = {
-            "method": "sell",
-            "market": "BTC",
-            "coin": ticker,
-            "amount": "{:.8f}".format(amount),
-            "price": "{:.8f}".format(ask)
-        }
+        query_parameters = getQueryParameters(SELL, ticker, amount, ask)
         response = self._create_signed_request(query_parameters)
 
         return response['success']
@@ -42,13 +36,7 @@ class TuxExchange(ExchangeBase):
             :param bid: float
             :param ticker: string
         '''
-        query_parameters = {
-            "method": "buy",
-            "market": "BTC",
-            "coin": ticker,
-            "amount": "{:.8f}".format(amount),
-            "price": "{:.8f}".format(bid)
-        }
+        query_parameters = getQueryParameters(BUY, ticker, amount, bid)
         response = self._create_signed_request(query_parameters)
 
         return response['success']
@@ -71,9 +59,7 @@ class TuxExchange(ExchangeBase):
     def get_my_open_orders(self):
         ''' Returns all open orders for the authenticated user '''
 
-        query_parameters = {
-            "method": "getmyopenorders"
-        }
+        query_parameters = { "method": "getmyopenorders" }
 
         return self._create_signed_request(query_parameters)
 

--- a/merkato/exchanges/tux_exchange/utils.py
+++ b/merkato/exchanges/tux_exchange/utils.py
@@ -1,0 +1,10 @@
+def getQueryParameters(type, ticker, amount, price):
+	formatted_amount = "{:.8f}".format(amount)
+	formatted_price = "{:.8f}".format(price)
+	return {
+		"method": type,
+		"market": "BTC",
+		"coin": ticker,
+		"amount": formatted_amount,
+		"price": formatted_price
+	}

--- a/merkato/merkato.py
+++ b/merkato/merkato.py
@@ -1,7 +1,7 @@
 import time
 import json
 
-from merkato.exchanges.tux_exchange import TuxExchange
+from merkato.exchanges.tux_exchange.exchange import TuxExchange
 from merkato.utils import create_price_data
 from merkato.constants import BUY, SELL, ID, PRICE
 

--- a/merkato/merkato.py
+++ b/merkato/merkato.py
@@ -1,7 +1,7 @@
 import time
 import json
 
-from merkato.exchanges.exchange import Exchange
+from merkato.exchanges.tux_exchange import TuxExchange
 from merkato.utils import create_price_data
 from merkato.constants import BUY, SELL, ID, PRICE
 
@@ -10,7 +10,7 @@ DEBUG = True
 
 class Merkato(object):
     def __init__(self, configuration, ticker, spread, ask_budget, bid_budget):
-        self.exchange = Exchange(configuration)
+        self.exchange = TuxExchange(configuration)
         self.distribution_strategy = 1
         self.ticker = ticker # i.e. 'XMR_BTC'
         self.spread = spread # i.e '15
@@ -33,14 +33,14 @@ class Merkato(object):
                 amount = tx['amount']
                 price = tx[PRICE]
                 sold.append(tx)
-                self.buy(amount, float(price) - self.spread, self.ticker)
+                self.exchange.buy(amount, float(price) - self.spread, self.ticker)
 
             if tx['type'] == BUY:
                 print(BUY)
                 amount = tx['amount']
                 price = tx[PRICE]
                 bought.append(tx)
-                self.sell(amount, float(price) + self.spread, self.ticker)
+                self.exchange.sell(amount, float(price) + self.spread, self.ticker)
 
     def create_relative_bid_ladder(self,):
         # a ladder that can be user configured (via gui)

--- a/tests/test_exchange_tux.py
+++ b/tests/test_exchange_tux.py
@@ -2,7 +2,7 @@ import unittest
 from mock import mock, patch, call
 from freezegun import freeze_time
 
-from merkato.exchanges.tux_exchange import TuxExchange
+from merkato.exchanges.tux_exchange.exchange import TuxExchange
 
 class TuxExchangeTestCase(unittest.TestCase):
 	def setUp(self):


### PR DESCRIPTION
Hi guys, this is the PR that moves from a OOP structure like

Merkato -> Exchange -> TuxExchange

to 

Merkato -> TuxExchange

I believe this is cleaner implementation, with the tradeoff being some code re-use that we no longer would have the the 'Exchange' as written above. Now all 'Exchange' methods are brought to the exchange specific class i.e. TuxExchange, and implemented alongside the internal api calls.

For example TuxExchange has a _buy and buy method. Buy is called from the merkato object which then calls _buy which makes the api call itself.
