### PR TITLE
 massive bugfix, and greater testing flow 

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -89,7 +89,7 @@ class Bot(ttk.Frame):
             print("updating bot/graph")
             
             if not self.stub:
-                context = self.bot.update_order_book()
+                context = self.bot.update()
                 
             else:
                 context = self.graph.fake_data()

--- a/db_init_script.py
+++ b/db_init_script.py
@@ -32,11 +32,19 @@ def main():
     complete_merkato_configs = generate_complete_merkato_configs(merkatos)
     print(complete_merkato_configs)
     print(merkatos)
+    context = merkato.update()
+    visualize_orderbook(context["orderbook"])
     while True:
         context = merkato.update()
-        pprint.pprint(context)
-        visualize_orderbook(context["orderbook"])
-        time.sleep(10)
+        print("\n"*10)
+        print("lowest ask:  ", context["orderbook"]["asks"][0])
+        print("current price:  ",context["price"][1])
+        print("highest bid:  ", context["orderbook"]["bids"][0])
+        if context["filled_orders"]:
+            print("---- Filled: -----")
+            pprint.pprint(context["filled_orders"])
+            visualize_orderbook(context["orderbook"])
+        time.sleep(.2)
 
 if __name__ == '__main__':
     main()

--- a/graph.py
+++ b/graph.py
@@ -377,24 +377,21 @@ class Graph(tk.Frame):
             ...
             ]
             '''
-            if "buy" in data["filled_orders"]:
 
-                for filled in data["filled_orders"]["buy"]:
-                    self.coin_balance.set(str(float(self.coin_balance.get()) + filled[1]))
-                    self.base_balance.set(str(float(self.base_balance.get()) - (filled[1] * filled[0])))
-                    bx = self.date_formatter(filled[2])  # date
-                    by = filled[0]
+            for filled in data["filled_orders"]:
+                if "buy" == filled["type"]:
+                    self.coin_balance.set(str(float(self.coin_balance.get()) + float(filled["amount"])))
+                    self.base_balance.set(str(float(self.base_balance.get()) - (float(filled["amount"]) * float(filled["price"]))))
+                    bx = self.date_formatter(filled["date"])  # date
+                    by = float(filled["price"])
                     self.x_bought.append(bx)
                     self.y_bought.append(by)
-        # -----------------------------------------------------
-        if "filled_orders" in data:
-            if "sell" in data["filled_orders"]:
 
-                for filled in data["filled_orders"]["sell"]:
-                    self.coin_balance.set(str(float(self.coin_balance.get()) - filled[1]))
-                    self.base_balance.set(str(float(self.base_balance.get()) + (filled[1] * filled[0])))
-                    sx = self.date_formatter(filled[2])  # date
-                    sy = filled[0]
+                elif "sell" == filled["type"]:
+                    self.coin_balance.set(str(float(self.coin_balance.get()) - float(filled["amount"])))
+                    self.base_balance.set(str(float(self.base_balance.get()) + (float(filled["amount"]) * float(filled["price"]))))
+                    sx = self.date_formatter(filled["date"])  # date
+                    sy = float(filled["price"])
                     self.x_sold.append(sx)
                     self.y_sold.append(sy)
 

--- a/merkato/exchanges/test_exchange/exchange.py
+++ b/merkato/exchanges/test_exchange/exchange.py
@@ -25,6 +25,7 @@ class TestExchange(ExchangeBase):
         self.price = price
         self.retries = 3
         self.limit_only = True
+        self.DEBUG = 3
         
     def debug(self, level, header, *args):
         if level <= self.DEBUG:
@@ -37,6 +38,7 @@ class TestExchange(ExchangeBase):
 
     def _sell(self, amount, ask,):
         self.orderbook.addAsk(self.user_id, amount, ask)
+
 
 
     def sell(self, amount, ask):
@@ -77,7 +79,9 @@ class TestExchange(ExchangeBase):
 
     def generate_fake_data(self, delta_range=[-3,3]):
         positive_or_negative = [-.2, .2]
+        self.debug(3,"test exchange.py gen fake data", self.price)
         self.price = abs(self.price * (1 + random.randint(*delta_range) / 100))  # percent walk of price, never < 0
+        self.debug(3, "test exchange.py gen fake data: new price", self.price)
         new_orders = self.orderbook.generate_fake_orders(self.price)        
         if new_orders:
             apply_resolved_orders(self.user_accounts, new_orders)
@@ -107,6 +111,14 @@ class TestExchange(ExchangeBase):
         }
 
     def get_my_trade_history(self):
+        try:
+            if not self.order_history:
+                return []
+            alt = [order for order in self.order_history[USER_ID]]
+        except:
+            self.debug(3, "get_my_trade_history", self.order_history, self.user_id)
+            raise
+        return alt
         return list(filter(lambda order: order[USER_ID] == self.user_id, self.order_history))
 
 
@@ -138,7 +150,8 @@ class TestExchange(ExchangeBase):
 
 
     def get_last_trade_price(self):
-        return self.get_ticker()
+        self.generate_fake_data()
+        return self.price
 
 
     def get_lowest_ask(self):

--- a/merkato/exchanges/test_exchange/orderbook.py
+++ b/merkato/exchanges/test_exchange/orderbook.py
@@ -31,20 +31,20 @@ class Orderbook:
         lowest_ask = self.asks[0]
 
         if type == ASK:
-            while lowest_ask < price:
+            while float(lowest_ask["price"]) < price:
                 self.asks.pop(0)
                 add_resolved_order(lowest_ask, resolved_orders, self.bid_ticker, self.ask_ticker)
                 lowest_ask = self.asks[0]
         else:
-            while highest_bid > price:
+            while float(highest_bid["price"]) > price:
                 self.bids.pop(0)
                 add_resolved_order(highest_bid, resolved_orders, self.ask_ticker, self.bid_ticker)
                 highest_bid = self.bids[0]
         return resolved_orders
 
     def generate_fake_orders(self, price):
-        is_bid_market_order = price < self.bids[0].price
-        is_ask_market_order = price > self.asks[0].price
+        is_bid_market_order = price < self.bids[0]["price"]
+        is_ask_market_order = price > self.asks[0]["price"]
 
         if(is_ask_market_order):
             return self.resolve_market_order(ASK, price)

--- a/merkato/exchanges/test_exchange/utils.py
+++ b/merkato/exchanges/test_exchange/utils.py
@@ -1,3 +1,5 @@
+DEBUG = True
+
 def create_order(user_id, amount, price):
     return {
         "user_id": user_id,
@@ -6,8 +8,10 @@ def create_order(user_id, amount, price):
     }
 
 def add_resolved_order(order, resolved_orders, add_ticker, sell_ticker):
-    user_id = order.user_id
-    resolved_order_amount_to_add = order.price / order.amount
+    user_id = order["user_id"]
+    if not user_id in resolved_orders:
+        resolved_orders[user_id] = {}
+    resolved_order_amount_to_add = float(order["price"]) / float(order["amount"])
 
     user_is_not_in_orders = user_id not in resolved_orders
     user_does_not_have_resolved_add_ticker = add_ticker not in  resolved_orders[user_id]
@@ -22,18 +26,25 @@ def add_resolved_order(order, resolved_orders, add_ticker, sell_ticker):
         resolved_orders[user_id][add_ticker] += resolved_order_amount_to_add
     
     if user_does_not_have_resolved_sell_ticker:
-        resolved_orders[user_id][sell_ticker] = -order.amount
+        resolved_orders[user_id][sell_ticker] = -float(order["amount"])
     else:
-        resolved_orders[user_id][sell_ticker] -= order.amount
+        resolved_orders[user_id][sell_ticker] -= float(order["amount"])
     
 
 def apply_resolved_orders(current_accounts, resolved_orders):
+    if resolved_orders:
+        if DEBUG:
+            print("-----------------------")
+            print("current accounts:\n\n",current_accounts)
+            print("-----------------------")
+            print("resolved orders:\n\n",resolved_orders)
+            print("-----------------------")
     for user_id, user in resolved_orders.items():
-        user_id = user.user_id
+        #user_id = user["user_id"]
         user_is_not_in_accounts = user_id not in current_accounts
         if user_is_not_in_accounts:
             current_accounts[user_id] = {}
-        for ticker, amount in user:
+        for ticker, amount in user.items():
             user_does_not_have_ticker = ticker not in  current_accounts[user_id]
             if user_does_not_have_ticker:
                 user[ticker] = resolved_orders[user_id][ticker]

--- a/merkato/merkato.py
+++ b/merkato/merkato.py
@@ -9,7 +9,7 @@ from merkato.utils import create_price_data, validate_merkato_initialization, ge
 import math
 from math import floor
 
-DEBUG = True
+DEBUG = False
 
 
 class Merkato(object):
@@ -30,7 +30,15 @@ class Merkato(object):
         if not merkato_does_exist:
             print('new merkato')
             self.distribute_initial_orders(base_reserve, coin_reserve)
-    # Make a second init for recovering a Merkato from the merkatos table here
+        self.DEBUG = 100
+
+    def debug(self, level, header, *args):
+        if level <= self.DEBUG:
+            print("-" * 10)
+            print("{}---> {}:".format(level, header))
+            for arg in args:
+                print("\t\t" + repr(arg))
+            print("-" * 10)
 
     def rebalance_orders(self, new_history, new_txes):
         # This function places a matching order for every new transaction since last run
@@ -44,6 +52,8 @@ class Merkato(object):
         bought = []
         index = -1*new_txes # Pop this many elements off the back of the transaction history
         newTransactionHistory = new_history[index:]
+        self.debug(2, "merkato.rebalance_orders")
+        self.debug(3, "merkato.rebalance_orders:  new txs", newTransactionHistory)
         
         for tx in newTransactionHistory:
 
@@ -100,7 +110,7 @@ class Merkato(object):
             
             current_order += 1
 
-        print(amount)
+        #print(amount)
 
     def distribute_initial_orders(self, total_base, total_alt):
         # waiting on vizualization for bids before running it as is
@@ -218,7 +228,7 @@ class Merkato(object):
 
             current_order += 1
 
-        print(amount)
+        #print(amount)
 
 
     def distribute_asks(self, total_to_distribute, step=1.0025):
@@ -300,7 +310,7 @@ class Merkato(object):
         # TODO: Make orders/orderbook variables less semantically similar
 
         orders = self.exchange.get_my_open_orders()
-        print(orders)
+        #print(orders)
 
         # Create a dictionary to store our desired orderbook
         orderbook = dict()
@@ -369,12 +379,12 @@ class Merkato(object):
 
     def update(self):
         # Get current state of trade history before placing orders
-        print(self.history)
+        #print(self.history)
         hist_len = len(self.history)
         now = str(time.time())
         last_trade_price = self.exchange.get_last_trade_price()
 
-        print("Time: " + now)
+        #print("Time: " + now)
 
         new_history = self.exchange.get_my_trade_history()
         new_hist_len = len(new_history)

--- a/merkato/utils/diagnostics.py
+++ b/merkato/utils/diagnostics.py
@@ -64,6 +64,7 @@ def visualize_orderbook(orderbook, bps=999):
     draw_depth(orderbook, bps=bps)
     plt.grid()
     plt.show()
+    plt.close()
     
 if __name__ == "__main__":
     visualize_orderbook(example_tux_orderbook)


### PR DESCRIPTION
 I got a lot of progress, but TestExchange.exchange.get_my_trade_history is not returning stuff in the right format for merkato.rebalance_orders. I tried to dissect it, but I epect it needs to be completely rewritten with desired format in mind.

3---> get_my_trade_history:
                [{20: {'XMR': 31.688663628936794, 'BTC': -0.29970994856685}}]
                20
----------
Traceback (most recent call last):
  File "db_init_script.py", line 50, in <module>
    main()
  File "db_init_script.py", line 38, in main
    context = merkato.update()
  File "/home/manbearpig/bin/merkato/merkato/merkato.py", line 389, in update
    new_history = self.exchange.get_my_trade_history()
  File "/home/manbearpig/bin/merkato/merkato/exchanges/test_exchange/exchange.py", line 117, in get_my_trade_history
    alt = [order for order in self.order_history[USER_ID]]
TypeError: list indices must be integers or slices, not str


