### PR TITLE
persist via GUI

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -15,17 +15,17 @@ from tkinter import ttk
 
 class Bot(ttk.Frame):
 
-    def __init__(self, 
-                app,
-                parent,
-                owner,
-                exchange_config = None,
-                stub = False,
-                auto_start = False,
-                starting_stats=None,
-                *args,
-                **kwargs
-                ):
+    def __init__(self,
+                 app,
+                 parent,
+                 owner,
+                 persist = None,
+                 stub = False,
+                 auto_start = False,
+                 starting_stats=None,
+                 *args,
+                 **kwargs
+                 ):
         ttk.Frame.__init__(self, parent, style="app.TFrame", *args, **kwargs)
         self.app = app # root
         self.parent = parent # containing frame
@@ -38,7 +38,7 @@ class Bot(ttk.Frame):
         self.exchange_title = "<exchange>"
         
         if self.stub:
-            self.name = "XMR/BTC   Kraken"
+            self.name = "XMR/BTC  Stub"
 
         else:
             self.name = "New Merkato"
@@ -49,10 +49,10 @@ class Bot(ttk.Frame):
         #self.auth_frame = ttk.Frame(self, style="app.TFrame")
         self.bot = None
 
-        if exchange_config:
-            self.name = exchange_config["coin"] + "/" + exchange_config["base"] + "    " + exchange_config["exchange"]
+        if persist:
+            self.name = persist["coin"] + "/" + persist["base"] + "    " + persist["configuration"]["exchange"]
             self.title_var.set(str(self.name))
-            self.bot = Merkato(**exchange_config) #presumably from db
+            self.bot = Merkato(**persist) #presumably from db
 
         # --------------------
         self.exchange_frame = ttk.Frame(self, style="app.TFrame")
@@ -80,7 +80,7 @@ class Bot(ttk.Frame):
         # --------------------
         self.util_frame = ttk.Frame(self, style="app.TFrame")
         self.kill_button = ttk.Button(self.util_frame, text="Kill", cursor="shuttle", command=self.kill)
-        self.kill_button.grid(row=0, column=0, sticky=tk.NE, padx=(10,5), pady=(15,5))
+        self.kill_button.grid(row=0, column=0, sticky=tk.SE, padx=(10,5), pady=(15,5))
         # --------------------
         if not starting_stats:
             starting_stats= {"price_x": []}
@@ -96,7 +96,7 @@ class Bot(ttk.Frame):
     def update(self):
 
         if self.stub or self.bot: # then we have something to update
-            print("updating bot/graph")
+            print("---------------  updating %s ----------------------" % self.name)
             
             if not self.stub:
                 context = self.bot.update()
@@ -141,12 +141,7 @@ class Bot(ttk.Frame):
 
         if not self.stub:
             try:
-                merkatos = get_all_merkatos()
-                complete_merkato_configs = generate_complete_merkato_configs(merkatos)
-                print(merkatos)
-                print(complete_merkato_configs)
-                self.bot = Merkato(**self.merk_args)
-
+              self.bot = Merkato(**self.merk_args)
             except Exception as e:
                 MessageBox.showerror("Bot Start Fail", str(e) + repr(self.merk_args))
 

--- a/simple_app.py
+++ b/simple_app.py
@@ -1,7 +1,8 @@
 import merkato.utils.database_utils as db
+from merkato.utils import generate_complete_merkato_configs
 #from exchange import Exchange
 from merkato.merkato import Merkato
-
+from pprint import pprint
 import matplotlib
 matplotlib.use("TkAgg")
 from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg, NavigationToolbar2TkAgg
@@ -133,11 +134,24 @@ if __name__ == "__main__":
         db.create_exchanges_table()
 
     db.insert_exchange("test", public_api_key='abc', private_api_key='123', limit_only=True)
+    merkatos = db.get_all_merkatos()
+    complete_merkato_configs = generate_complete_merkato_configs(merkatos)
 
     # ------------------------------
     app = App(root, tk.RIGHT)
 
-    for i in range(3):
+    for persisted in complete_merkato_configs:
+        pprint(persisted)
+        bot = Bot(root, app(), app, persist=persisted)
+        app.add_screen(bot,
+                       "null",
+                       textvariable=bot.title_var,
+                       bg="gray75",
+                       fg="black",
+                       selectcolor="lightblue"
+                       )
+
+    for i in range(1):
         bot = Bot(root, app(), app,)
         app.add_screen(bot,
                        "null",


### PR DESCRIPTION
broken until complete_merkato_configs returns bid/ask reserve

@15chrjef 

{'base': 'BTC',
 'coin': 'XMR',
 'configuration': {'exchange': 'test',
                   'limit_only': True,
                   'private_api_key': '123',
                   'public_api_key': 'abc'},
 'spread': '0.05'}
Traceback (most recent call last):
  File "/home/manbearpig/bin/merkato/simple_app.py", line 145, in <module>
    bot = Bot(root, app(), app, persist=persisted)
  File "/home/manbearpig/bin/merkato/bot.py", line 55, in __init__
    self.bot = Merkato(**persist) #presumably from db
TypeError: __init__() missing 2 required positional arguments: 'coin_reserve' and 'base_reserve'
